### PR TITLE
Adds install-repo-deps and all-todeb functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ echo >> ~/.bashrc && echo source `pwd`/rosbash.bash >> ~/.bashrc
 source ~/.bashrc
 install_todeb
 ```
-    
+
 Restart your shell for the changes to take effect.
 
 ## Usage
@@ -42,7 +42,7 @@ or
 cd ~/ros_ws
 install
 ```
-    
+
 Any of these shells can be exited with the command *exit* or by pressing *Ctrl-D*.
 
 ### Manipulating ROS environment variables
@@ -63,13 +63,19 @@ rosip 192.168.0.1     # Set ROS_IP to 192.168.0.1 and remove ROS_HOSTNAME
 ### Generating Debian Packages
 Based on [these instructions](https://gist.github.com/awesomebytes/196eab972a94dd8fcdd69adfe3bd1152).
 ```bash
-# run this one time to install dependencies. Requires sudo
-install_todeb
+## run this one time to install dependencies. Requires sudo
+install-rosbash
 ## once your workspace is sources in a terminal
 todeb ROS_PACKAGE_NAME
 ## this will generate a Debian package in a folder called deb at the root of your workspace.
+
+## to generate Debian packages for all packages in your workspace
+all-todeb
+
+## to install all publicly available dependencies for the packages in your workspace
+install-repo-deps
 ```
-    
+
 ### Other useful commands
 
 ```bash

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -2,23 +2,23 @@
 
 # ROS NETWORK CONFIGURATION
 
-rosnetwork() { 
-    env | egrep "ROS_MASTER_URI|ROS_IP|ROS_HOSTNAME" 
+rosnetwork() {
+    env | egrep "ROS_MASTER_URI|ROS_IP|ROS_HOSTNAME"
 }
 
-rosmaster() {    
+rosmaster() {
     export ROS_MASTER_URI=http://$1:11311
     rosnetwork
     rosprompt
 }
 
-rosip() {    
+rosip() {
     export ROS_IP=$1
     unset ROS_HOSTNAME
     rosnetwork
 }
 
-roshostname() {    
+roshostname() {
     export ROS_HOSTNAME=$1
     unset ROS_IP
     rosnetwork
@@ -36,12 +36,12 @@ rosprompt() {
 
 # Loads child Bash environment with bashrc, prompt, and any start command as a parameter
 rosshell() {
-    F=`mktemp`    
+    F=`mktemp`
     echo source ~/.bashrc >> $F
     echo $* >> $F
     echo rosprompt >> $F
     #~ echo ros >> $F
-    bash --rcfile $F    
+    bash --rcfile $F
 }
 
 urdf_display() {
@@ -156,4 +156,12 @@ install_todeb() {
     wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
     sudo apt-get update
     sudo apt-get install python-catkin-tools python-bloom dpkg-dev debhelper -y
+}
+
+# Install all public deps of a private catkin repo
+install-repo-deps() {
+    for p in $(catkin list --quiet -u); do
+        echo Installing public dependencies for $p...
+        rosdep install -i $p
+    done
 }

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -169,10 +169,15 @@ install-rosbash() {
 
 # Install all public deps of a private catkin repo
 install-repo-deps() {
+    # Remember current dir
+    local ORIG_DIR="$(pwd)"
+    roscd && cd ..
     for p in $(catkin list --quiet -u); do
         echo Installing public dependencies for $p...
         rosdep install -i $p
     done
+    # Return to initial dir for convenience
+    cd $ORIG_DIR
 }
 
 # Generate deb files for all private packages in repo; installs them

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -175,7 +175,7 @@ install-repo-deps() {
     done
 }
 
-# Generate debfiles for all private packages in repo
+# Generate deb files for all private packages in repo; installs them
 all-todeb() {
     # Remember current dir
     local ORIG_DIR="$(pwd)"


### PR DESCRIPTION
Adds two new functions:

# `all-todeb`
Builds and installs every package in the repo. Keeps building packages that fail until either no more packages can be built or dependencies are finally resolved and all are built. Uses `todeb`.

# `install-repo-deps`
Calls `rosdep install -i` on every package in the repo.

# Additional Changes
* `todeb` runs `rosdep install -i` on the package at the beginning to ensure public dependencies are installed.
* `todeb` returns and exit status.
* Changes `install_todeb` to `install-rosbash` as it now applies to multiple different tools within rosbash.
* Converts some variables to `local` for safety.
* Removes trailing whitespace.