### PR TITLE
`toggle-hostname` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ groovy
 indigo
 hydro
 kinetic
+lunar
+melodic
 ```
 
 The following commands start a new shell with a workspace environment (either devel or install) for instance:
@@ -79,10 +81,11 @@ install-repo-deps
 ### Other useful commands
 
 ```bash
-cm     # Finds the root folder of your workspace, run catkin_make and comes back to current folder
+cm # Finds the root folder of your workspace, run catkin_make and comes back to current folder
 rosrefresh    # Rebuilds the index of packages in your workspace (useful if your packages are not seen)
-urdf_display my_robot.urdf     # Display the URDF model in the GUI
-xacro_display my_robot.xacro     # Generates the URDF from XACRO and display it in GUI
+urdf_display my_robot.urdf # Display the URDF model in the GUI
+xacro_display my_robot.xacro # Generates the URDF from XACRO and display it in GUI
+toggle-hostname # displays/hides local hostname in the prompt 
 rn # rosnode list
 rni # rosnode info
 rte # rostopic echo

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -39,11 +39,11 @@ rosprompt() {
 }
 
 toggle-hostname() {
-    local PATTERN="^$(hostname) .+$"
+    local PATTERN='^\$\(hostname\) .+$'
     if [[ $PS1 =~ $PATTERN ]]; then
-        export PS1=${PS1#$(hostname) }
+        export PS1=${PS1#\$(hostname) }
     else
-        export PS1="$(hostname) $PS1"
+        export PS1="\$(hostname) $PS1"
     fi
 }
 

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -41,7 +41,7 @@ rosprompt() {
 toggle-hostname() {
     local PATTERN="^$(hostname) .+$"
     if [[ $PS1 =~ $PATTERN ]]; then
-        rosprompt
+        export PS1=${PS1#$(hostname) }
     else
         export PS1="$(hostname) $PS1"
     fi

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -38,8 +38,13 @@ rosprompt() {
     export PS1='\[\033[0;31m\]${ROS_DISTRO[@]:0:1} \[\033[0;34m\]$ROSPATHNAME\[\033[0;32m\]@$MASTER\[\033[0m\]:\[\033[0;36m\]\w\[\033[0m\]\[\033[33m\]$(parse_git_branch)\[\033[00m\]> '
 }
 
-show-hostname() {
-    export PS1="$(hostname) $PS1"
+toggle-hostname() {
+    local PATTERN="^$(hostname) .+$"
+    if [[ $PS1 =~ $PATTERN ]]; then
+        rosprompt
+    else
+        export PS1="$(hostname) $PS1"
+    fi
 }
 
 # Loads child Bash environment with bashrc, prompt, and any start command as a parameter

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -38,6 +38,10 @@ rosprompt() {
     export PS1='\[\033[0;31m\]${ROS_DISTRO[@]:0:1} \[\033[0;34m\]$ROSPATHNAME\[\033[0;32m\]@$MASTER\[\033[0m\]:\[\033[0;36m\]\w\[\033[0m\]\[\033[33m\]$(parse_git_branch)\[\033[00m\]> '
 }
 
+show-hostname() {
+    export PS1="$(hostname) $PS1"
+}
+
 # Loads child Bash environment with bashrc, prompt, and any start command as a parameter
 rosshell() {
     F=`mktemp`


### PR DESCRIPTION
Adds the toggle-hostname function that adds the hostname of the machine to the front of the bash prompt. Calling it again removes this hostname.