### PR TITLE
Update README with updated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd rosbash
 # Add an empty line, add the source command
 echo >> ~/.bashrc && echo source `pwd`/rosbash.bash >> ~/.bashrc
 source ~/.bashrc
-install_todeb
+install_rosbash
 ```
 
 Restart your shell for the changes to take effect.


### PR DESCRIPTION
### Description:
In a recent PR (https://github.com/Sotilrac/rosbash/pull/6) `install_todep` was changed to `install-rosbash`. This fix changes that in one missed instance in the README.

### Manual Testing:
1. Follow `Installation` instructions on rosbash master, see that `install_todep` isn't found when following the instructions on `master`.
2. See that `install-rosbash` succeeds when executed instead.