### PR TITLE
Fix README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd rosbash
 # Add an empty line, add the source command
 echo >> ~/.bashrc && echo source `pwd`/rosbash.bash >> ~/.bashrc
 source ~/.bashrc
-install_rosbash
+install-rosbash
 ```
 
 Restart your shell for the changes to take effect.


### PR DESCRIPTION
### Description:
In a recent PR (#8) I tried to updated the README to the new command `install-rosbash`, but I accidentally kept the snake_casing of the old `install_todep` command and made it `install_rosbash`. This fixes that.

### Manual Testing:
Follow Installation instructions on rosbash master, see that install_rosbash isn't found when following the instructions on master.
See that install-rosbash succeeds when executed instead.