### PR TITLE
Automatically install rosdeps when building debs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ todeb ROS_PACKAGE_NAME
 all-todeb
 
 ## to install all publicly available dependencies for the packages in your workspace
-install-repo-deps
+install_deps
 ```
 
 ### Other useful commands

--- a/rosbash.bash
+++ b/rosbash.bash
@@ -130,7 +130,7 @@ todeb() {
     fi
     local DEB_DIR="$(cd $DEB_DIR && pwd)"
     # Install public deps
-    rosdep install -i $1
+    rosdep install -i -y $1
     # Generate debian package
     roscd $1 &&
     # Remove old debian and obj-* dirs


### PR DESCRIPTION
Adds the -y flag to rosdep install when building packages to install without prompt & fixes a typo in the README